### PR TITLE
Update the base image to Fedora 32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:31
+FROM fedora:32
 
 LABEL \
     name="datagrepper" \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains configuration and supporting files for running
 [datagrepper](https://github.com/fedora-infra/datagrepper) in a container.
-The image is built on top of the [CentOS](https://www.centos.org/) 7 base
+The image is built on top of a [Fedora](https://hub.docker.com/_/fedora) base
 image.
 
 ## Build


### PR DESCRIPTION
This is required to update Datagrepper to 0.9.6.