### PR TITLE
Fix the path to the static directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,6 @@ RUN rm -f /etc/fedmsg.d/*
 COPY fedmsg.d/ /etc/fedmsg.d/
 
 COPY datagrepper.cfg /etc/datagrepper/
-COPY static/ /usr/lib/python3.7/site-packages/datagrepper/static/
+COPY static/ /usr/lib/python3.8/site-packages/datagrepper/static/
 
 USER 1001


### PR DESCRIPTION
Fedora 32 upgraded its Python version to 3.8, so the path in the Dockerfile must be updated accordingly.