### PR TITLE
update to Fedora 33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM registry.fedoraproject.org/fedora-minimal:33
 
 LABEL \
     name="datagrepper" \
@@ -11,6 +11,7 @@ ENV GUNICORN_CMD_ARGS="--bind=0.0.0.0:8080 --workers=4 --access-logfile=-"
 
 ENV DNF_CMD="dnf -y --setopt=deltarpm=0 --setopt=install_weak_deps=false"
 ENV EXTRA_RPMS="python3-fedmsg-meta-umb python-fedmsg-meta-umb-doc"
+ENV PYTHON_VERSION="3.9"
 
 EXPOSE 8080
 
@@ -27,6 +28,6 @@ RUN rm -f /etc/fedmsg.d/*
 COPY fedmsg.d/ /etc/fedmsg.d/
 
 COPY datagrepper.cfg /etc/datagrepper/
-COPY static/ /usr/lib/python3.8/site-packages/datagrepper/static/
+COPY static/ /usr/lib/python${PYTHON_VERSION}/site-packages/datagrepper/static/
 
 USER 1001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,23 @@
 FROM registry.fedoraproject.org/fedora-minimal:33
 
-LABEL \
-    name="datagrepper" \
-    vendor="EXD SP" \
-    license="GPLv3"
+LABEL name="datagrepper" \
+      vendor="Red Hat EXD Software Production" \
+      license="GPL-2.0-or-later" \
+      org.opencontainers.image.title="datagrepper" \
+      org.opencontainers.image.description="datagrepper in a container, suitable for running on OpenShift" \
+      org.opencontainers.image.vendor="Red Hat EXD Software Production" \
+      org.opencontainers.image.authors="EXD Messaging Guild <exd-guild-messaging@redhat.com>" \
+      org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.url="https://github.com/release-engineering/datagrepper-container" \
+      org.opencontainers.image.source="https://github.com/release-engineering/datagrepper-container" \
+      org.opencontainers.image.documentation="https://github.com/fedora-infra/datagrepper" \
+      distribution-scope="public"
 
 ENTRYPOINT ["gunicorn-3"]
 CMD ["datagrepper.app:app"]
 ENV GUNICORN_CMD_ARGS="--bind=0.0.0.0:8080 --workers=4 --access-logfile=-"
 
-ENV DNF_CMD="dnf -y --setopt=deltarpm=0 --setopt=install_weak_deps=false"
+ENV DNF_CMD="microdnf --setopt=install_weak_deps=0"
 ENV EXTRA_RPMS="python3-fedmsg-meta-umb python-fedmsg-meta-umb-doc"
 ENV PYTHON_VERSION="3.9"
 


### PR DESCRIPTION
Pull the Fedora 33 image from the official Fedora registry, to avoid issues with Docker Hub throttling pulls. Also use the fedora-minimal image to reduce image size and attack surface.

Get the Python version from an environment variable, rather than hard-coding it in the static file path. This should make it more visible, and easier to update when the Python version changes in the future.

Also use microdnf, and add opencontainers labels.