### PR TITLE
include the fedmsg_meta_umb version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.fedoraproject.org/fedora:33
 
 ENV DATAGREPPER_VERSION="0.9.7"
+ENV FEDMSG_META_UMB_VERSION="0.0.4"
 
 LABEL name="datagrepper" \
       version="$DATAGREPPER_VERSION" \


### PR DESCRIPTION
This gives us something to bump when we need to ensure the build is really being performed, and
not just pulled from the cache.